### PR TITLE
When we have an error in an underlying connection, propagate it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea

--- a/lib/multiconnect/connectable.rb
+++ b/lib/multiconnect/connectable.rb
@@ -16,12 +16,18 @@ module Multiconnect
         end
 
         def request(action, *args)
+          errors = []
+
           self._connections.each do |connection|
-            result = connection.execute(action, *args)
-            return result if result.success?
+            begin
+              result = connection.execute(action, *args)
+              return result if result.success?
+            rescue => e
+              errors << e
+            end
           end
 
-          raise Multiconnect::Error::UnsuccessfulRequest.new( class: self, action: action )
+          raise Multiconnect::Error::UnsuccessfulRequest.new( class: self, action: action, errors: errors )
         end
       end
     end

--- a/lib/multiconnect/connection/base.rb
+++ b/lib/multiconnect/connection/base.rb
@@ -27,7 +27,7 @@ module Multiconnect
 
       rescue => e
         report_error(e)
-        Result.new
+        raise e
       end
 
       private

--- a/lib/multiconnect/error/unsuccessful_request.rb
+++ b/lib/multiconnect/error/unsuccessful_request.rb
@@ -4,11 +4,21 @@ module Multiconnect
       def initialize(opts = {})
         @class    = opts.fetch :class, nil
         @action   = opts.fetch :action, nil
+        @errors   = opts.fetch :errors, []
       end
 
       def message
-        "#{@class}: Failed to request #{@action}"
+        "#{@class}: Failed to request #{@action}#{error_details}"
       end
+
+      private
+
+      def error_details
+        if @errors.present?
+          " - #{@errors.map(&:message).join(', ')}"
+        end
+      end
+
     end
   end
 end

--- a/test/multiconnect_error_test.rb
+++ b/test/multiconnect_error_test.rb
@@ -5,4 +5,16 @@ class MulticonnectErrorTest < Minitest::Test
     assert_equal "User: Failed to request blah", 
                   Multiconnect::Error::UnsuccessfulRequest.new(class: User, action: "blah").message
   end
+
+  def test_message_can_include_inner_details
+    assert_equal "User: Failed to request blah - I segfaulted, I timed out on localhost:3000",
+                 Multiconnect::Error::UnsuccessfulRequest.new(class: User, action: "blah", errors: errors).message
+  end
+
+  private
+
+  def errors
+    [Exception.new('I segfaulted'), Exception.new('I timed out on localhost:3000')]
+  end
+
 end


### PR DESCRIPTION
We report on errors to our error reporter, but we do not provide anything locally.  We should re-raise exceptions from the connections for our caller to handle.  Then it can provide that information in the error message.

This turns an error like "Failed to request foo" into "Failed to request foo - I segfaulted, I timed out on localhost:3000, server returned error 400", where the comma-separated information is the error from each successively failed tried connection.
